### PR TITLE
Add travis CI testing file for easier fault finding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: cpp
+
+before_install:
+ - sudo apt-get update
+ - sudo apt-get install -y build-essential git libtool bison flex automake autoconf libreadline6-dev
+
+script:
+ - autoreconf --force
+ - ./configure
+ - make


### PR DESCRIPTION
Travis CI is a valuable tool to validate pull requests and gain a better
understanding of the project's health. Not everybody will attempt
building source code they contribute, or have a standardized build
environment. Enabling Travis on this project will provide coherency in
that regard and provide semi-instant feedback on pull requests.
