### PR TITLE
Fix manpage syntax errors

### DIFF
--- a/src/peval/peval.1
+++ b/src/peval/peval.1
@@ -50,7 +50,7 @@
 .\"
 .TH peval 1 local
 .SH NAME
-peval
+peval \- Low level evaluation tool for writing router config generators
 .SH SYNOPSIS
 .B peval
 .RI [ options ]\ [<expression>]

--- a/src/rpsl/irrtoolset-errors.1
+++ b/src/rpsl/irrtoolset-errors.1
@@ -48,7 +48,7 @@
 .\"
 .TH IRRToolSet 1 local
 .SH NAME
-IRRToolSet error and warning messages
+irrtoolset-errors \- IRRToolSet error and warning messages
 .SH DESCRIPTION
 .PP
 The goal of this document is to clarify the possible errors you may encounter when using IRRToolSet. Some of these errors are listed on the manual pages for the tools. If you didn't find the error on the manual page of the tool you were using, please refer to this page. Some errors with obvious explanation are listed here for reference, but to not have any documentation. Still, if description is unclear or unsufficient, please report to irrtoolset@lists.isc.org.

--- a/src/rpslcheck/rpslcheck.1
+++ b/src/rpslcheck/rpslcheck.1
@@ -50,7 +50,7 @@
 .\"
 .TH rpslcheck 1 local
 .SH NAME
-rpslcheck -- an RPSL syntax checker
+rpslcheck \- an RPSL syntax checker
 .SH SYNOPSIS
 .B rpslcheck
 .RI [ flags ]

--- a/src/rtconfig/rtconfig.1
+++ b/src/rtconfig/rtconfig.1
@@ -50,7 +50,7 @@
 .\"
 .TH rtconfig 1 local
 .SH NAME
-rtconfig
+rtconfig \- Tool for producing configs from IRR routing policies
 .SH SYNOPSIS
 .B rtconfig
 .RI [ flags ]


### PR DESCRIPTION
According to Debian's lintian (which complains about the present manpage syntax) the correct syntax for the NAME section is a single-word "name" followed by " \\- " then followed by a one-line short description. This commit conforms to that.
