### PR TITLE
- Reorders some of the junos output so that the router will accept it

### DIFF
--- a/src/rtconfig/f_junos.hh
+++ b/src/rtconfig/f_junos.hh
@@ -113,7 +113,7 @@ private:
    inline void  printCommunity(std::ostream &os, unsigned int i);
    int          printCommunityList(std::ostream &os, ItemList *args);
    int          printCommunitySet(std::ostream &os, CommunitySet *set, bool exact);
-   void         printActions(std::ostream &os, PolicyActionList *action, ItemAFI *afi);
+   void         printActions(std::ostream &os, PolicyActionList *action, ItemAFI *afi,std::ostringstream &lastCout);
    void         printMartians();
    int          print(NormalExpression *ne, PolicyActionList *actn, int import_flag, ItemAFI *afi);
    int          printDeclarations(NormalExpression *ne, PolicyActionList *actn, int import_flag);


### PR DESCRIPTION
- Unlike Cisco, Junos uses the same namespace for v4 & v6 prefix lists, so we need to increment our internal numbers for both each time we use one to avoid duplicates
