### PR TITLE
Initial support of community.delete for Cisco

### DIFF
--- a/src/rtconfig/f_cisco.hh
+++ b/src/rtconfig/f_cisco.hh
@@ -157,6 +157,7 @@ private:
    int          printPacketFilter(SetOfIPv6Prefix &set);
    inline void  printCommunity(std::ostream &os, unsigned int i);
    void         printCommunityList(std::ostream &os, ItemList *args);
+   int         printCommunitySetList(std::ostream &os, ItemList *args);
    void         printActions(std::ostream &os, PolicyActionList *action, ItemAFI *afi);
    int          print(NormalExpression *ne, PolicyActionList *actn, int import_flag, ItemAFI *afi);
    bool         printNeighbor(int import, ASt asno, ASt peerAS, char *neighbor, bool peerGroup, ItemAFI *peer_afi, ItemAFI *filter_afi);


### PR DESCRIPTION
Implement community.delete() for Cisco.

I really need a way to allow stars in this, eg we use community.delete(4739:*) internally a lot, but I've no idea the best way to achieve it in code. Our patch is a bit hard coded internally. This is a nice generic working patch but doesn't support wildcards :(
