### PR TITLE
Implement new command @Rtconfig importPG for junos to make import polici...

### DIFF
--- a/src/rtconfig/command.l
+++ b/src/rtconfig/command.l
@@ -87,7 +87,7 @@ typedef struct _KeyWord {
 
 static KeyWord keywords[] = {
 "import",                  KW_IMPORT,
-"importPG",                KW_IMPORT_PG,
+"importPeerGroup",         KW_IMPORT_PEERGROUP,
 "export",                  KW_EXPORT,
 "exportGroup",             KW_EXPORT_GROUP,
 "importGroup",             KW_IMPORT_GROUP,

--- a/src/rtconfig/command.l
+++ b/src/rtconfig/command.l
@@ -87,6 +87,7 @@ typedef struct _KeyWord {
 
 static KeyWord keywords[] = {
 "import",                  KW_IMPORT,
+"importPG",                KW_IMPORT_PG,
 "export",                  KW_EXPORT,
 "exportGroup",             KW_EXPORT_GROUP,
 "importGroup",             KW_IMPORT_GROUP,

--- a/src/rtconfig/command.y
+++ b/src/rtconfig/command.y
@@ -102,7 +102,7 @@ int xx_eof = 0;
 %token <val> TKN_WORD
 
 %token <val> KW_IMPORT
-%token <val> KW_IMPORT_PG
+%token <val> KW_IMPORT_PEERGROUP
 %token <val> KW_EXPORT
 %token <val> KW_EXPORT_GROUP
 %token <val> KW_IMPORT_GROUP
@@ -193,13 +193,13 @@ import_line: KW_IMPORT TKN_ASNUM TKN_IP TKN_ASNUM TKN_IP {
 }
 ;
 
-importpg_line: KW_IMPORT_PG TKN_ASNUM TKN_IP TKN_ASNUM TKN_IP TKN_WORD {
+importpg_line: KW_IMPORT_PEERGROUP TKN_ASNUM TKN_IP TKN_ASNUM TKN_IP TKN_WORD {
    /*
    cout << "!" << endl
         << "!LINE " << yylineno << " -- import" << endl
         << "!" << endl;
    */
-   rtConfig->importPG($2, $3, $4, $5, $6);
+   rtConfig->importPeerGroup($2, $3, $4, $5, $6);
    delete $3;
    delete $5;
 }

--- a/src/rtconfig/command.y
+++ b/src/rtconfig/command.y
@@ -102,6 +102,7 @@ int xx_eof = 0;
 %token <val> TKN_WORD
 
 %token <val> KW_IMPORT
+%token <val> KW_IMPORT_PG
 %token <val> KW_EXPORT
 %token <val> KW_EXPORT_GROUP
 %token <val> KW_IMPORT_GROUP
@@ -155,6 +156,7 @@ input: input_line '\n'
 ;
 
 input_line: import_line
+| importpg_line
 | export_line
 | export_group_line
 | import_group_line
@@ -186,6 +188,18 @@ import_line: KW_IMPORT TKN_ASNUM TKN_IP TKN_ASNUM TKN_IP {
         << "!" << endl;
    */
    rtConfig->importP($2, $3, $4, $5);
+   delete $3;
+   delete $5;
+}
+;
+
+importpg_line: KW_IMPORT_PG TKN_ASNUM TKN_IP TKN_ASNUM TKN_IP TKN_WORD {
+   /*
+   cout << "!" << endl
+        << "!LINE " << yylineno << " -- import" << endl
+        << "!" << endl;
+   */
+   rtConfig->importPG($2, $3, $4, $5, $6);
    delete $3;
    delete $5;
 }

--- a/src/rtconfig/f_junos.cc
+++ b/src/rtconfig/f_junos.cc
@@ -886,7 +886,7 @@ bool JunosConfig::printNeighbor(int import, ASt asno,
    const char *direction = (import == IMPORT) ? "import" : "export";
 
    cout << "protocols {\n"
-	<< "   bgp {\n";
+       << "   bgp {\n";
    if (!peerGroup) {
      cout << "      group peer-" << neighbor << " {\n";
      cout << "         type external;\n";
@@ -895,7 +895,7 @@ bool JunosConfig::printNeighbor(int import, ASt asno,
      cout << "      group peers-prng-" << pset << " {\n";
      cout << "         type external;\n";
    }
-   cout	<< "         neighbor " << neighbor << " {\n"
+   cout        << "         neighbor " << neighbor << " {\n"
 	<< "            " << direction << " ";
 
    if ((exportStatics && import == EXPORT) || supressMartians)
@@ -1108,11 +1108,11 @@ void JunosConfig::importP(ASt asno, MPPrefix *addr,
 
    for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
        printNeighbor(IMPORT, asno, peerAS, peer_addr->get_ip_text(), false, (ItemAFI *) peer_afi, (ItemAFI *) afi, (char *) false);
-    } 
+   } 
 }
 
-void JunosConfig::importPeerGroup(ASt asno, MPPrefix *addr, 
-			 ASt peerAS, MPPrefix *peer_addr, char *pset) {
+void JunosConfig::importPeerGroup(ASt asno, MPPrefix *addr,
+                        ASt peerAS, MPPrefix *peer_addr, char *pset) {
 
    // Made asno part of the map name if it's not changed by users
    sprintf(mapName, mapNameFormat, peerAS, mapCount++);
@@ -1126,18 +1126,18 @@ void JunosConfig::importPeerGroup(ASt asno, MPPrefix *addr,
     }
 
    // get matching import attributes
-   AutNumSelector<AttrImport> itr(autnum, "import", 
-				  NULL, peerAS, peer_addr, addr);
+   AutNumSelector<AttrImport> itr(autnum, "import",
+                                 NULL, peerAS, peer_addr, addr);
    AutNumSelector<AttrImport> itr1(autnum, "mp-import",
-				  NULL, peerAS, peer_addr, addr);
+                                 NULL, peerAS, peer_addr, addr);
 
    List<FilterAction> *common_list = itr.get_fa_list();
    common_list->splice(*(itr1.get_fa_list()));
 
    FilterAction *fa = common_list->head();
-   if (! fa)	{
-   		printPolicyWarning(asno, addr, peerAS, peer_addr, "import/mp-import");
-      	return;
+   if (! fa)   {
+               printPolicyWarning(asno, addr, peerAS, peer_addr, "import/mp-import");
+       return;
    }
 
    ItemList *afi_list = itr.get_afi_list();
@@ -1150,37 +1150,37 @@ void JunosConfig::importPeerGroup(ASt asno, MPPrefix *addr,
    int last;
 
    for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
-		last = 0;
-		for (fa = common_list->head(); fa && !last; fa = common_list->next(fa)) {
+               last = 0;
+               for (fa = common_list->head(); fa && !last; fa = common_list->next(fa)) {
 
-			ne = NormalExpression::evaluate(new FilterAFI((ItemAFI *) afi->dup(), fa->filter), peerAS);
-			last = printDeclarations(ne, fa->action, IMPORT);
-			delete ne;
-		}
+                       ne = NormalExpression::evaluate(new FilterAFI((ItemAFI *) afi->dup(), fa->filter), peerAS);
+                       last = printDeclarations(ne, fa->action, IMPORT);
+                       delete ne;
+               }
    }
 
    for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
-		last = 0;
-   		for (fa = common_list->head(); fa && !last; fa = common_list->next(fa)) {
-			ne = NormalExpression::evaluate(new FilterAFI((ItemAFI *) afi->dup(), fa->filter), peerAS);
-			last = print(ne, fa->action, IMPORT, (ItemAFI *) afi);
-			delete ne;
-		}
+               last = 0;
+               for (fa = common_list->head(); fa && !last; fa = common_list->next(fa)) {
+                       ne = NormalExpression::evaluate(new FilterAFI((ItemAFI *) afi->dup(), fa->filter), peerAS);
+                       last = print(ne, fa->action, IMPORT, (ItemAFI *) afi);
+                       delete ne;
+               }
    }
 
    cout << "   policy-statement " << mapName << " {\n"
-	<< "      term " << mapName << "-catch-rest {\n"
-	<< "         then reject;\n"
+       << "      term " << mapName << "-catch-rest {\n"
+       << "         then reject;\n"
         << "      }\n"
-	<< "   }\n"
-	<< "}\n\n";
+       << "   }\n"
+       << "}\n\n";
 
    ItemAFI *peer_afi = new ItemAFI(peer_addr->get_afi());
 
    for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
        printNeighbor(IMPORT, asno, peerAS, peer_addr->get_ip_text(), pset, (ItemAFI *) peer_afi, (ItemAFI *) afi, pset);
-   } 
-}
+    }
+ }
 
 void JunosConfig::static2bgp(ASt asno, MPPrefix *addr) {
 

--- a/src/rtconfig/f_junos.cc
+++ b/src/rtconfig/f_junos.cc
@@ -1071,7 +1071,7 @@ void JunosConfig::importP(ASt asno, MPPrefix *addr,
    } 
 }
 
-void JunosConfig::importPG(ASt asno, MPPrefix *addr, 
+void JunosConfig::importPeerGroup(ASt asno, MPPrefix *addr, 
 			 ASt peerAS, MPPrefix *peer_addr, char *pset) {
 
    // Made asno part of the map name if it's not changed by users

--- a/src/rtconfig/f_junos.hh
+++ b/src/rtconfig/f_junos.hh
@@ -76,7 +76,7 @@ public:
       routeMapID = 1;
    }
    void importP(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr);
-   void importPG(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr, char* pset);
+   void importPeerGroup(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr, char* pset);
    void exportP(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr);
    void exportGroup(ASt as, char *pset);
    void importGroup(ASt as, char *pset);

--- a/src/rtconfig/f_junos.hh
+++ b/src/rtconfig/f_junos.hh
@@ -76,6 +76,7 @@ public:
       routeMapID = 1;
    }
    void importP(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr);
+   void importPG(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr, char* pset);
    void exportP(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr);
    void exportGroup(ASt as, char *pset);
    void importGroup(ASt as, char *pset);
@@ -119,7 +120,7 @@ private:
    int          print(NormalExpression *ne, PolicyActionList *actn, int import_flag, ItemAFI *afi);
    int          printDeclarations(NormalExpression *ne, PolicyActionList *actn, int import_flag);
    bool         printNeighbor(int import, ASt asno, ASt peerAS, char *neighbor, 
-			      bool peerGroup, ItemAFI *peer_afi, ItemAFI *filter_afi);
+			      bool peerGroup, ItemAFI *peer_afi, ItemAFI *filter_afi, char *pset);
    void printAccessList(SetOfIPv6Prefix& nets) {
       bool save = useAclCaches;
       useAclCaches = false;

--- a/src/rtconfig/rtconfig.1
+++ b/src/rtconfig/rtconfig.1
@@ -212,6 +212,8 @@ This command will use the named inet-rtr object,
 and configure import/mp-import and export/mp-export policies
 for each of the BGP4 peers of the router 
 (using the peer attribute).
+.IP "@rtconfig importPeerGroup <ASN-1> <rtr-1> <ASN-2> <rtr-2> <peering-set-name>"
+Required when using JunOS to place the import policies inside the correct peer group.
 .IP "@rtconfig importGroup <ASN-1> <peering-set-name>"
 .IP "@rtconfig exportGroup <ASN-1> <peering-set-name>"
 <peering-set-name> is a name of a peering set object.

--- a/src/rtconfig/rtconfig.hh
+++ b/src/rtconfig/rtconfig.hh
@@ -68,6 +68,13 @@ public:
                         MPPrefix* peerAddr) {
       std::cerr << "Error: import not implemented" << std::endl;
    }
+   virtual void importPG(ASt as,
+                        MPPrefix* addr,
+                        ASt peerAS,
+                        MPPrefix* peerAddr,
+			char *pset) {
+      std::cerr << "Error: import not implemented" << std::endl;
+   }
    virtual void exportP(ASt as,
                         MPPrefix* addr,
                         ASt peerAS,

--- a/src/rtconfig/rtconfig.hh
+++ b/src/rtconfig/rtconfig.hh
@@ -68,7 +68,7 @@ public:
                         MPPrefix* peerAddr) {
       std::cerr << "Error: import not implemented" << std::endl;
    }
-   virtual void importPG(ASt as,
+   virtual void importPeerGroup(ASt as,
                         MPPrefix* addr,
                         ASt peerAS,
                         MPPrefix* peerAddr,


### PR DESCRIPTION
...es work with peer groups.

eg:
@RtConfig importPG <My AS> <My IP> <Peer AS> <Peer IP> <peer group name>

This is the same as regular import with the addition of a peer group name as the last argument.  This then causes output like:

protocols {
   bgp {
      group peers-prng-<peer group name> {
         type external;
         neighbor <Peer IP> {
            import [ <route map name> ];
         }
      }
   }
}