### PR TITLE
Fix community.delete() support for IOS XR

### DIFF
--- a/src/rtconfig/f_ciscoxr.cc
+++ b/src/rtconfig/f_ciscoxr.cc
@@ -861,6 +861,16 @@ inline void CiscoXRConfig::printCommunity(ostream &os, unsigned int i) {
    }
 }
 
+int CiscoXRConfig::printCommunitySetList(ostream &os, ItemList *args) {
+
+ int aclID = communityMgr.newID();
+ os << "community-set commset" << aclID << "-permit " << endl;
+ CiscoXRConfig::printCommunityList(os, args);
+ os << endl << "end-set" << endl;
+
+return aclID;
+}
+
 void CiscoXRConfig::printCommunityList(ostream &os, ItemList *args) {
 
 bool first = true;
@@ -880,20 +890,26 @@ bool first = true;
       }
 
       if (typeid(*cmnty) == typeid(ItemWORD)) {
-	 if (!strcasecmp(((ItemWORD *)cmnty)->word, "no_advertise"))
+	 if (!strcasecmp(((ItemWORD *)cmnty)->word, "no_advertise")) {
+            if (first) first=false; else os << ", ";
 	    printCommunity(os, COMMUNITY_NO_ADVERTISE);
-	 else if (!strcasecmp(((ItemWORD *)cmnty)->word, "no_export"))
+	 } else if (!strcasecmp(((ItemWORD *)cmnty)->word, "no_export")) {
+            if (first) first=false; else os << ", ";
 	    printCommunity(os, COMMUNITY_NO_EXPORT);
-	 else if (!strcasecmp(((ItemWORD *)cmnty)->word,"no_export_subconfed"))
+	 } else if (!strcasecmp(((ItemWORD *)cmnty)->word,"no_export_subconfed")) {
+            if (first) first=false; else os << ", ";
 	    printCommunity(os, COMMUNITY_NO_EXPORT_SUBCONFED);
-	 else
+	 } else {
+            if (first) first=false; else os << ", ";
 	    printCommunity(os, COMMUNITY_INTERNET);
+         }
 	 continue;
       }
 
       if (typeid(*cmnty) == typeid(ItemList)) {
 	 int high = ((ItemINT *) ((ItemList *) cmnty)->head())->i;
 	 int low  = ((ItemINT *) ((ItemList *) cmnty)->tail())->i;
+         if (first) first=false; else os << ", ";
 	 printCommunity(os, (high << 16) + low);
 	 continue;
       }
@@ -985,7 +1001,8 @@ void CiscoXRConfig::printActions(ostream &os, PolicyActionList *actions, ItemAFI
 	    os << ") additive" << endl;
          } else if (actn->rp_method == dctn_rp_community_delete) {
             for (int j=0; j < ifcount; j++) os << " ";
-           os << "delete community in internode-delete" << endl;
+            int commlist = printCommunitySetList(delayedout, actn->args);
+            os << "delete community in commset-" << commlist << "-permit" << endl;
 	 } else
 	    UNIMPLEMENTED_METHOD;
 	 continue;

--- a/src/rtconfig/f_ciscoxr.hh
+++ b/src/rtconfig/f_ciscoxr.hh
@@ -159,6 +159,7 @@ private:
    int          printPacketFilter(SetOfIPv6Prefix &set);
    inline void  printCommunity(std::ostream &os, unsigned int i);
    void         printCommunityList(std::ostream &os, ItemList *args);
+   int          printCommunitySetList(std::ostream &os, ItemList *args);
    void         printActions(std::ostream &os, PolicyActionList *action, ItemAFI *afi);
    int          print(NormalExpression *ne, PolicyActionList *actn, int import_flag, ItemAFI *afi);
    bool         printNeighbor(int import, ASt asno, ASt peerAS, char *neighbor, bool peerGroup, ItemAFI *peer_afi, ItemAFI *filter_afi);


### PR DESCRIPTION
remove hard coded internode-delete lol and add generic support.

This also lacks support for wild cards which I strongly desire as per the similar pull request for vanilla IOS.
