### PR TITLE
Fix an instance where bad output for XR was produced

### DIFF
--- a/src/rtconfig/f_ciscoxr.cc
+++ b/src/rtconfig/f_ciscoxr.cc
@@ -745,13 +745,16 @@ ListOf2Ints* CiscoXRConfig::printASPaths(regexp_nf& path) {
          CiscoXRConfig::printRE(delayedout, *ri->re, aclID, true);
 	 rc->mark = 1;
 
-         delayedout << "\nend-set" << endl << endl;
-	 delayedout << "exit" << endl << "as-path-set as-set" << aclID << "-deny" << endl;
-         delayedout << "end-set" << endl << endl;
 
       } else {
 	 rc->mark = 0;
       }
+   }
+
+   if (!needNewAclpermit) {
+     delayedout << "\nend-set" << endl << endl;
+     delayedout << "exit" << endl << "as-path-set as-set" << aclID << "-deny" << endl;
+     delayedout << "end-set" << endl << endl;
    }
 
    // pass 2


### PR DESCRIPTION
Bad/original output:
as-path-set as-set51-deny
end-set
,
ios-regex '^(_1239)+(_7018)+_'
end-set
exit
as-path-set as-set51-deny
end-set
,

ios-regex '^(_1239)+(_3549)+_'
end-set

corrected output is:
as-path-set as-set51-deny
ios-regex '^(_1239)+(_7018)+_',
ios-regex '^(_1239)+(_3549)+_'
end-set
