### PR TITLE
Fix but with -cisco_peer_templates that would cause output like "neig…

### DIFF
--- a/src/rtconfig/f_cisco.cc
+++ b/src/rtconfig/f_cisco.cc
@@ -1146,7 +1146,7 @@ bool CiscoConfig::printNeighbor(int import,
        cout << " route-map " << mapName << " " << direction << "\n";
      cout << " remove-private-as\n";
      cout << "exit-peer-policy\n!\n";
-   } if (peerGroup && !CiscoConfig::peerTemplates) {
+   } else if (peerGroup && !CiscoConfig::peerTemplates) {
      cout << " neighbor " << neighbor << " peer-group\n";
    } else {
      cout << " neighbor "   << neighbor << " remote-as " << peerAS << "\n";

--- a/src/rtconfig/f_cisco.cc
+++ b/src/rtconfig/f_cisco.cc
@@ -959,7 +959,7 @@ void CiscoConfig::printActions(ostream &os, PolicyActionList *actions, ItemAFI *
    }
 
    os << "exit\n"; // exit route map config mode 
-   os << delayoutput.str() << endl;
+   os << delayoutput.str();
    delayoutput.str("");
 
 }


### PR DESCRIPTION
…hbor <prng name> remote-as 0" to be incorrectly added to the config