### PR TITLE
Fixed instance where printing a community list would not end in a new…

### DIFF
--- a/src/rtconfig/f_cisco.cc
+++ b/src/rtconfig/f_cisco.cc
@@ -848,6 +848,7 @@ void CiscoConfig::printCommunityList(ostream &os, ItemList *args) {
 	 continue;
       }
    }
+   os << endl;
 }
 
 int CiscoConfig::printCommunitySetList(ostream &os, ItemList *args) {

--- a/src/rtconfig/f_cisco.cc
+++ b/src/rtconfig/f_cisco.cc
@@ -848,7 +848,6 @@ void CiscoConfig::printCommunityList(ostream &os, ItemList *args) {
 	 continue;
       }
    }
-   os << endl;
 }
 
 int CiscoConfig::printCommunitySetList(ostream &os, ItemList *args) {
@@ -857,7 +856,7 @@ int CiscoConfig::printCommunitySetList(ostream &os, ItemList *args) {
    os << "!\nno ip community-list " << aclID << "\n";
    os << "ip community-list " << aclID << " permit ";
    CiscoConfig::printCommunityList(os, args);
-   os << "!\n";
+   os << "\n!\n";
 
 return aclID;
 }


### PR DESCRIPTION
…line

eg:
ip community-list 101 permit  1111:20 1111:50 no-export!

(should be a \n before the !)