### PR TITLE
Implement new command @Rtconfig importPG for junos to make import pol…

### DIFF
--- a/src/rtconfig/command.l
+++ b/src/rtconfig/command.l
@@ -87,6 +87,7 @@ typedef struct _KeyWord {
 
 static KeyWord keywords[] = {
 "import",                  KW_IMPORT,
+"importPeerGroup",         KW_IMPORT_PEERGROUP,
 "export",                  KW_EXPORT,
 "exportGroup",             KW_EXPORT_GROUP,
 "importGroup",             KW_IMPORT_GROUP,

--- a/src/rtconfig/command.y
+++ b/src/rtconfig/command.y
@@ -102,6 +102,7 @@ int xx_eof = 0;
 %token <val> TKN_WORD
 
 %token <val> KW_IMPORT
+%token <val> KW_IMPORT_PEERGROUP
 %token <val> KW_EXPORT
 %token <val> KW_EXPORT_GROUP
 %token <val> KW_IMPORT_GROUP
@@ -155,6 +156,7 @@ input: input_line '\n'
 ;
 
 input_line: import_line
+| import_peergroup_line
 | export_line
 | export_group_line
 | import_group_line
@@ -186,6 +188,18 @@ import_line: KW_IMPORT TKN_ASNUM TKN_IP TKN_ASNUM TKN_IP {
         << "!" << endl;
    */
    rtConfig->importP($2, $3, $4, $5);
+   delete $3;
+   delete $5;
+}
+;
+
+import_peergroup_line: KW_IMPORT_PEERGROUP TKN_ASNUM TKN_IP TKN_ASNUM TKN_IP TKN_WORD {
+   /*
+   cout << "!" << endl
+        << "!LINE " << yylineno << " -- import" << endl
+        << "!" << endl;
+   */
+   rtConfig->importPeerGroup($2, $3, $4, $5, $6);
    delete $3;
    delete $5;
 }

--- a/src/rtconfig/f_junos.cc
+++ b/src/rtconfig/f_junos.cc
@@ -874,7 +874,7 @@ int JunosConfig::print(NormalExpression *ne, PolicyActionList *actn,
 
 bool JunosConfig::printNeighbor(int import, ASt asno,
 				ASt peerAS, char *neighbor, bool peerGroup,
-				ItemAFI *peer_afi, ItemAFI *filter_afi) {
+				ItemAFI *peer_afi, ItemAFI *filter_afi, char *pset) {
    bool afi_activate = false;
 
    if (! printRouteMap)
@@ -886,11 +886,16 @@ bool JunosConfig::printNeighbor(int import, ASt asno,
    const char *direction = (import == IMPORT) ? "import" : "export";
 
    cout << "protocols {\n"
-	<< "   bgp {\n"
-	<< "      group peer-" << neighbor << " {\n"
-	<< "         type external;\n"
-        << "         peer-as " << peerAS << ";\n"
-	<< "         neighbor " << neighbor << " {\n"
+       << "   bgp {\n";
+   if (!peerGroup) {
+     cout << "      group peer-" << neighbor << " {\n";
+     cout << "         type external;\n";
+     cout << "         peer-as " << peerAS << ";\n";
+   } else {
+     cout << "      group peers-prng-" << pset << " {\n";
+     cout << "         type external;\n";
+   }
+   cout        << "         neighbor " << neighbor << " {\n"
 	<< "            " << direction << " ";
 
    if ((exportStatics && import == EXPORT) || supressMartians)
@@ -1022,7 +1027,7 @@ void JunosConfig::exportP(ASt asno, MPPrefix *addr,
    ItemAFI *peer_afi = new ItemAFI(peer_addr->get_afi());
 
    for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
-       printNeighbor(EXPORT, asno, peerAS, peer_addr->get_ip_text(), false, (ItemAFI *) peer_afi, (ItemAFI *) afi);
+       printNeighbor(EXPORT, asno, peerAS, peer_addr->get_ip_text(), false, (ItemAFI *) peer_afi, (ItemAFI *) afi, (char *) false);
    }
 }
 
@@ -1102,9 +1107,80 @@ void JunosConfig::importP(ASt asno, MPPrefix *addr,
    ItemAFI *peer_afi = new ItemAFI(peer_addr->get_afi());
 
    for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
-       printNeighbor(IMPORT, asno, peerAS, peer_addr->get_ip_text(), false, (ItemAFI *) peer_afi, (ItemAFI *) afi);
+       printNeighbor(IMPORT, asno, peerAS, peer_addr->get_ip_text(), false, (ItemAFI *) peer_afi, (ItemAFI *) afi, (char *) false);
    } 
 }
+
+void JunosConfig::importPeerGroup(ASt asno, MPPrefix *addr,
+                        ASt peerAS, MPPrefix *peer_addr, char *pset) {
+
+   // Made asno part of the map name if it's not changed by users
+   sprintf(mapName, mapNameFormat, peerAS, mapCount++);
+
+   // get the aut-num object
+   const AutNum *autnum = irr->getAutNum(asno);
+
+   if (!autnum) {
+      cerr << "Error: no object for AS" << asno << endl;
+      return;
+    }
+
+   // get matching import attributes
+   AutNumSelector<AttrImport> itr(autnum, "import",
+                                 NULL, peerAS, peer_addr, addr);
+   AutNumSelector<AttrImport> itr1(autnum, "mp-import",
+                                 NULL, peerAS, peer_addr, addr);
+
+   List<FilterAction> *common_list = itr.get_fa_list();
+   common_list->splice(*(itr1.get_fa_list()));
+
+   FilterAction *fa = common_list->head();
+   if (! fa)   {
+               printPolicyWarning(asno, addr, peerAS, peer_addr, "import/mp-import");
+       return;
+   }
+
+   ItemList *afi_list = itr.get_afi_list();
+   afi_list->merge(*(itr1.get_afi_list()));
+
+   cout << "policy-options {\n";
+
+   NormalExpression *ne;
+   NormalExpression done;
+   int last;
+
+   for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
+               last = 0;
+               for (fa = common_list->head(); fa && !last; fa = common_list->next(fa)) {
+
+                       ne = NormalExpression::evaluate(new FilterAFI((ItemAFI *) afi->dup(), fa->filter), peerAS);
+                       last = printDeclarations(ne, fa->action, IMPORT);
+                       delete ne;
+               }
+   }
+
+   for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
+               last = 0;
+               for (fa = common_list->head(); fa && !last; fa = common_list->next(fa)) {
+                       ne = NormalExpression::evaluate(new FilterAFI((ItemAFI *) afi->dup(), fa->filter), peerAS);
+                       last = print(ne, fa->action, IMPORT, (ItemAFI *) afi);
+                       delete ne;
+               }
+   }
+
+   cout << "   policy-statement " << mapName << " {\n"
+       << "      term " << mapName << "-catch-rest {\n"
+       << "         then reject;\n"
+        << "      }\n"
+       << "   }\n"
+       << "}\n\n";
+
+   ItemAFI *peer_afi = new ItemAFI(peer_addr->get_afi());
+
+   for (Item *afi = afi_list->head(); afi; afi = afi_list->next(afi)) {
+       printNeighbor(IMPORT, asno, peerAS, peer_addr->get_ip_text(), pset, (ItemAFI *) peer_afi, (ItemAFI *) afi, pset);
+    }
+ }
 
 void JunosConfig::static2bgp(ASt asno, MPPrefix *addr) {
 

--- a/src/rtconfig/f_junos.hh
+++ b/src/rtconfig/f_junos.hh
@@ -76,6 +76,7 @@ public:
       routeMapID = 1;
    }
    void importP(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr);
+   void importPeerGroup(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr, char* pset);
    void exportP(ASt as, MPPrefix* addr, ASt peerAS, MPPrefix* peerAddr);
    void exportGroup(ASt as, char *pset);
    void importGroup(ASt as, char *pset);
@@ -119,7 +120,7 @@ private:
    int          print(NormalExpression *ne, PolicyActionList *actn, int import_flag, ItemAFI *afi);
    int          printDeclarations(NormalExpression *ne, PolicyActionList *actn, int import_flag);
    bool         printNeighbor(int import, ASt asno, ASt peerAS, char *neighbor, 
-			      bool peerGroup, ItemAFI *peer_afi, ItemAFI *filter_afi);
+			      bool peerGroup, ItemAFI *peer_afi, ItemAFI *filter_afi, char *pset);
    void printAccessList(SetOfIPv6Prefix& nets) {
       bool save = useAclCaches;
       useAclCaches = false;

--- a/src/rtconfig/rtconfig.1
+++ b/src/rtconfig/rtconfig.1
@@ -213,6 +213,8 @@ and configure import/mp-import and export/mp-export policies
 for each of the BGP4 peers of the router 
 (using the peer attribute).
 .IP "@rtconfig importGroup <ASN-1> <peering-set-name>"
+.IP "@rtconfig importPeerGroup <ASN-1> <rtr-1> <ASN-2> <rtr-2> <peering-set-name>"
+Required when using JunOS to place the import policies inside the correct peer group.
 .IP "@rtconfig exportGroup <ASN-1> <peering-set-name>"
 <peering-set-name> is a name of a peering set object.
 This command instructs rtconfig to generate import/mp-import (export/mp-export) filters

--- a/src/rtconfig/rtconfig.hh
+++ b/src/rtconfig/rtconfig.hh
@@ -68,6 +68,13 @@ public:
                         MPPrefix* peerAddr) {
       std::cerr << "Error: import not implemented" << std::endl;
    }
+   virtual void importPeerGroup(ASt as,
+                        MPPrefix* addr,
+                        ASt peerAS,
+                        MPPrefix* peerAddr,
+                       char *pset) {
+      std::cerr << "Error: import not implemented" << std::endl;
+   }
    virtual void exportP(ASt as,
                         MPPrefix* addr,
                         ASt peerAS,


### PR DESCRIPTION
…icies work with peer groups.

Replaces pull request 27

eg:
@RtConfig importPG

This is the same as regular import with the addition of a peer group name as the last argument. This then causes output like:

protocols {
bgp {
group peers-prng- {
type external;
neighbor {
import [ ];
}
}
}
}